### PR TITLE
Remove dependency on CoreDNS to redirect mitmproxy dns traffic

### DIFF
--- a/deployment/nginx/starpoint_proxy.nginx
+++ b/deployment/nginx/starpoint_proxy.nginx
@@ -26,6 +26,7 @@ server {
                 proxy_set_header Host $host;
                 proxy_set_header X-Forwarded-For $remote_addr;
                 proxy_set_header X-Real-IP $remote_addr;
+                proxy_pass_request_headers on;
                 proxy_pass ${STARPOINT_REMOTE_URL}$request_uri;
         }
 }
@@ -38,6 +39,8 @@ server {
 
         server_name na.wdfp.kakaogames.com;
 
+        underscores_in_headers on;
+
         ssl_certificate ${STARPOINT_PUBKEY_PREFIX}_wdfp_global.crt;
         ssl_certificate_key $STARPOINT_PRIVATEKEY;
 
@@ -45,6 +48,7 @@ server {
                 proxy_set_header Host $host;
                 proxy_set_header X-Forwarded-For $remote_addr;
                 proxy_set_header X-Real-IP $remote_addr;
+                proxy_pass_request_headers on;
                 proxy_pass ${STARPOINT_REMOTE_URL}$request_uri;
         }
 }
@@ -59,6 +63,8 @@ server {
 
         server_name patch.wdfp.kakaogames.com;
 
+        underscores_in_headers on;
+
         ssl_certificate ${STARPOINT_PUBKEY_PREFIX}_wdfp_global.crt;
         ssl_certificate_key $STARPOINT_PRIVATEKEY;
 
@@ -66,6 +72,7 @@ server {
                 proxy_set_header Host $host;
                 proxy_set_header X-Forwarded-For $remote_addr;
                 proxy_set_header X-Real-IP $remote_addr;
+                proxy_pass_request_headers on;
                 proxy_pass ${STARPOINT_REMOTE_URL}/patch$request_uri;
         }
 }
@@ -78,6 +85,8 @@ server {
 
         server_name openapi-zinny3.game.kakaogames.com;
 
+        underscores_in_headers on;
+
         ssl_certificate ${STARPOINT_PUBKEY_PREFIX}_zinny3_openapi.crt;
         ssl_certificate_key $STARPOINT_PRIVATEKEY;
 
@@ -85,6 +94,7 @@ server {
                 proxy_set_header Host $host;
                 proxy_set_header X-Forwarded-For $remote_addr;
                 proxy_set_header X-Real-IP $remote_addr;
+                proxy_pass_request_headers on;
                 proxy_pass ${STARPOINT_REMOTE_URL}/openapi$request_uri;
         }
 }
@@ -97,6 +107,8 @@ server {
 
         server_name gc-openapi-zinny3.kakaogames.com;
 
+        underscores_in_headers on;
+
         ssl_certificate ${STARPOINT_PUBKEY_PREFIX}_zinny3_openapi_gc.crt;
         ssl_certificate_key $STARPOINT_PRIVATEKEY;
 
@@ -104,6 +116,7 @@ server {
                 proxy_set_header Host $host;
                 proxy_set_header X-Forwarded-For $remote_addr;
                 proxy_set_header X-Real-IP $remote_addr;
+                proxy_pass_request_headers on;
                 proxy_pass ${STARPOINT_REMOTE_URL}/openapi$request_uri;
         }
 }
@@ -116,6 +129,8 @@ server {
 
         server_name gc-infodesk-zinny3.kakaogames.com;
 
+        underscores_in_headers on;
+
         ssl_certificate ${STARPOINT_PUBKEY_PREFIX}_zinny3_infodesk_gc.crt;
         ssl_certificate_key $STARPOINT_PRIVATEKEY;
 
@@ -123,6 +138,7 @@ server {
                 proxy_set_header Host $host;
                 proxy_set_header X-Forwarded-For $remote_addr;
                 proxy_set_header X-Real-IP $remote_addr;
+                proxy_pass_request_headers on;
                 proxy_pass ${STARPOINT_REMOTE_URL}/infodesk$request_uri;
         }
 }

--- a/docs/connecting-android.md
+++ b/docs/connecting-android.md
@@ -1,16 +1,21 @@
 # Unrooted Android Connection Guide
+
 The following is a general guide for connecting the Android game client to Starpoint.
 
 ## Discovering Local IP Address (Windows)
+
 1. On your keyboard press the Windows key + X.
 2. Select ``Terminal``.
-2. In the window that just opened, type the following:
-   ```
+3. In the window that just opened, type the following:
+
+   ```sh
    ipconfig
    ```
-3. Locate your WiFi adapter's "IPv4 Address" under the "Wireless LAN adapter Wi-Fi:" section (e.g., `10.0.0.167`).
+
+4. Locate your WiFi adapter's "IPv4 Address" under the "Wireless LAN adapter Wi-Fi:" section (e.g., `10.0.0.167`).
    - The section will typically look like the following. Notice the "IPv4 Address. . ." entry.
-     ```
+
+     ```yaml
      Wireless LAN adapter Wi-Fi:
     
      Connection-specific DNS Suffix  . : <Excluded>
@@ -25,21 +30,22 @@ The following is a general guide for connecting the Android game client to Starp
      ```
 
 ## Starting the Server
+
 1. **In the following step, you may receive a Windows firewall popup. Hit "Allow".**
    - This step is crucial. If you do not hit allow you will encounter connection problems.
    - If the popup does not appear, you can continue.
 2. In the directory where you installed Starpoint, locate and run the ``start.bat`` file.
    - **If you receive a Windows firewall popup, hit "Allow".**
    - For non-Windows users or manual setup, see the "Manual Server Start Method" section below.
-3. Three windows should open.
+3. Two windows should open.
    - One of the windows should eventually show ``StarPoint is listening on http://localhost:8000``. This may take a minute or two, give it some time.
-   - Another one of the windows should show ``.:53`` at the top.
    - The other window should show ``Loading script mitm-redirect-traffic.py`` at the top.
 4. A new tab will open in your web browser. Keep this open for later.
 
 ## Device/Emulator Setup
 
 ### Installing & Setting up WG Tunnel
+
 1. Install the WG Tunnel app from the [Google Play Store](https://play.google.com/store/apps/details?id=com.zaneschepke.wireguardautotunnel) or [Github](https://github.com/zaneschepke/wgtunnel/releases/tag/3.4.7)
 2. Ensure your Android device is on the same network as your computer.
 3. Open the WG Tunnel app.
@@ -49,24 +55,18 @@ The following is a general guide for connecting the Android game client to Starp
 6. Tap "Add from QR code"
 7. Scan the QR code that is visible in the tab that opened up in your browser.
 8. At the top of the screen, there will be some numbers; i.e. 10.0.0.167.
-9. Long hold on these numbers until three icons appear.
-10. Tap the gear/cog/settings icon.
-11. In the bottom right corner, press the pencil icon.
-12. Tap "WireGuard".
-13. Locate the "DNS servers" field under the "Interface" section.
-14. Replace the value in the field with your computer's IP address (e.g., ``10.0.0.167``).
-15. Tap the save button in the bottom right corner of the screen.
-16. At the top of the screen, there will be some numbers; i.e. 10.0.0.167.
-17. Tap the round button to the right of these numbers.
-18. Accept the VPN popup.
-19. Tap the round button to the right of these numbers again.
+9. Tap the round button to the right of these numbers.
+10. Accept the VPN popup.
+11. Tap the round button to the right of these numbers again.
 
-### (Optional) Manual WG Tunnel setup.
+### (Optional) Manual WG Tunnel setup
+
 If you have already turned on the WG Tunnel VPN, you may skip the following steps and jump to "Pinball App Setup" below.
 
 1. Go to the tab that opened up in your browser.
 2. Make note of the values to the left of the QR code. They will look like the below.
-   ```
+
+   ```ini
    [Interface]
    PrivateKey = <value>
    Address = 10.0.0.1/32
@@ -77,19 +77,21 @@ If you have already turned on the WG Tunnel VPN, you may skip the following step
    AllowedIPs = 0.0.0.0/0
    Endpoint = 10.0.0.167:51820
    ```
+
 3. In the WG tunnel app, tap the "+" button in the bottom right corner of the screen.
 4. Tap "WireGuard".
 5. Tap "Create from scratch".
 6. In the top field, "Name", put "Pinball".
 7. In the next field, "Private key", put the ``PrivateKey`` value you noted earlier.
 8. In the "Addresses" field, put the ``Address`` value you noted earlier.
-9. In the "DNS servers" field, put your computer's IP address (e.g., ``10.0.0.167``).
+9. In the "DNS servers" field, put ``10.0.0.53``.
    - Do not put the value under the ``[Interface]`` section of the values you noted earlier.
 10. In the "Public key" field, put the ``PublicKey`` value you noted earlier.
 11. In the "Endpoint" field, put the ``Endpoint`` value you noted earlier.
 12. In the "Allowed IPs" field, put the ``AllowedIPs`` value you noted earlier.
 
 ### Pinball App Setup
+
 1. Clear all data for the pinball game via your device's settings.
    - You only have to do this once, do not clear your data every time you connect to Starpoint.
 2. Open the pinball game, and **sign in as a Guest**.
@@ -97,19 +99,18 @@ If you have already turned on the WG Tunnel VPN, you may skip the following step
 4. You will now be connected to Starpoint.
 
 ## (Optional) Manual Server Start Method
+
 1. Navigate to the .mitmproxy folder in the Starpoint install directory.
 2. Open a command prompt in this folder and run the following line:
-   ```
+
+   ```sh
    .\mitmweb.exe --mode wireguard --set connection_strategy=lazy -s ..\scripts\mitm-redirect-traffic.py
    ```
+
    - **Note**: The ``path/to/starpoint/directory`` portion of the below command should be replaced with the path to the directory where you installed Starpoint, keep the ``/scripts/mitm-redirect-traffic.py`` portion.
-3. Navigate to the .coredns folder in the Starpoint install directory.
-4. Open a command prompt in this folder and run the following line:
-   ```
-   .\coredns.exe
-   ```
-5. Go to the directory where you have Starpoint installed; open a new terminal, and start the server.
-   ```
+3. Go to the directory where you have Starpoint installed; open a new terminal, and start the server.
+
+   ```sh
    npm install
    npx tsc
    npm run dev

--- a/scripts/mitm-redirect-traffic.py
+++ b/scripts/mitm-redirect-traffic.py
@@ -1,7 +1,12 @@
-from mitmproxy import http
-import logging
+from mitmproxy import http, dns
+import ipaddress
+#import logging
 
 API_HOST = "localhost"
+# 198.51.100.0/24 subnet reserved for documentation, so it will never be used for anything else
+#We can black-hole this address because it will be discarded.
+API_DNS_REDIRECT_HOST = ipaddress.IPv4Address("198.51.100.140")
+DNS_TTL= 600
 API_PORT = 8000
 API_SCHEME = 'http'
 
@@ -22,6 +27,24 @@ hosts = {
     # patch
     "patch.wdfp.kakaogames.com": 3
 }
+
+#Magic domain taken from MITMproxy documentation
+host_redirects = dict([(hostname, f"{hostname}.mitm.it") for hostname in hosts.keys()])
+
+def dns_request(flow: dns.DNSFlow):
+    if not flow.request.query or flow.request.questions is None: return
+    #logging.info(f"[INFO] DNS request for {flow.request.questions}")
+    for question in flow.request.questions:
+        if question.type == 1 and (question.name in hosts or question.name in host_redirects): #Type is 1 when asking for an A record
+            #logging.info(f"[INFO] Matched DNS request for {question.name}")
+            flow.response.answers = [answer for answer in flow.response.answers if answer.name != question.name]
+            domain_redirect = host_redirects.get(question.name)
+            #TODO: Are the CNAME records still useful in this configuration? Might be better to remove them and the host_redirects altogether....
+            cname_rec = dns.ResourceRecord.CNAME(question.name, domain_redirect, ttl=DNS_TTL)
+            a_rec = dns.ResourceRecord.A(domain_redirect, API_DNS_REDIRECT_HOST, ttl=DNS_TTL)
+            flow.response.answers.append(cname_rec)
+            flow.response.answers.append(a_rec)
+    #logging.info(f"[INFO] Answered with {flow.response.answers}")
 
 def request(flow: http.HTTPFlow):
     #logging.info(f"[INFO] {flow.request.url}")


### PR DESCRIPTION
MITM proxy is capable of working with DNS requests, so I removed CoreDNS to simplify the runtime requirements. I also removed the CoreDNS instructions section from documentation, and changed affected documentation to reflect this. Also removed it from the start.bat and added an extra search method to find mitmproxy for android devices.

Since start-ios.bat doesn't have any CoreDNS in there anyway, it has been currently left as-is.