### PR TITLE
Update launch tasks for better debugging, add initial Dev Container support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,112 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Starpoint Dev with MITMproxy",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {
+			"installTools": true,
+			"version": "os-provided"
+		},
+		"ghcr.io/lukewiwa/features/shellcheck:0": {
+			"version": "stable"
+		},
+		"ghcr.io/warrenbuckley/codespace-features/sqlite": {}
+		// BUG:Install via the features method found to have infrequent success. Using pipx method instead to install system-wide.
+		// "ghcr.io/joshspicer/features/mitm-proxy": {
+		// 	"installRootCerts": true
+		// }
+	},
+	
+	//Make absolutely sure these are the exact ports forwarded here. We need to change the IP in the app's config anyway, but at least it would forward consistently.
+	//TODO: Does it matter if the port is consistent, or is it better to make it more likely to work and bind properly to the correct external ports?
+	//If this becomes more of a hassle, this can be changed, but outgoing ports will no longer be guaranteed to have the same ports as expected.
+	//51820: Wireguard
+	//8080: MITMproxy's actual proxy port
+	//8000: Starpoint UI
+	"appPort": [ "51820:51820/udp", 8080, 8000 ],
+	
+	// MITMproxy's Web UI
+	"forwardPorts": [ 8081 ],
+	
+	"onCreateCommand": "tempHoldEdit=\"$(tr -d '\\r' < deployment/devenv/starpoint-devcontainer-setup.sh)\"; printf \"%s\" \"$tempHoldEdit\" > deployment/devenv/starpoint-devcontainer-setup.sh; dash deployment/devenv/starpoint-devcontainer-setup.sh",
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postStartCommand": "dash deployment/devenv/starpoint-devcontainer-setup.sh --fix-file-escapes-only",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"terminal.integrated.defaultProfile.linux": "bash",
+				"python.defaultInterpreterPath": "~/starpoint-venv",
+				"python.terminal.activateEnvInCurrentTerminal": false,
+				"python.terminal.activateEnvironment": false,
+				//Required for phone connection. Should work regardless of local instance setting
+				"remote.localPortHost":"allInterfaces",
+				"files.associations": {
+					//Since we are never not using tailwind, allow all CSS files to be linted with the tailwind extension
+					"css":"tailwindcss"
+				},
+				"[css]": {
+					"editor.quickSuggestions": {
+						//TODO: Turn this off if determined to be too annoying.
+						//TODO: Turn on for HTML if determined to be useful enough there? (Unlikely to be that while not also being annoying.)
+						"strings": "on"
+					}
+				},
+				"explorer.fileNesting.enabled":true,
+				"explorer.fileNesting.patterns": {
+					"*.ts": "${capture}.js",
+					"*.js": "${capture}.js.map, ${capture}.min.js, ${capture}.d.ts",
+					"*.jsx": "${capture}.js",
+					"*.tsx": "${capture}.ts",
+					"tsconfig.json": "tsconfig.*.json",
+					"package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb",
+					"*.sqlite": "${capture}.${extname}-*",
+					"*.db": "${capture}.${extname}.*,${capture}.${extname}-*",
+					"*.sqlite3": "${capture}.${extname}-*",
+					"*.db3": "${capture}.${extname}-*",
+					"*.sdb": "${capture}.${extname}-*",
+					"*.s3db": "${capture}.${extname}-*"
+				},
+				"sqltools.connectionExplorer.groupConnected": true,
+				//TODO: Determine whether to move the two below into .vscode/settings.json or not.
+				//They were originally placed there by the extension to begin with and probably should continue to be there,
+				//but not everyone would use their associated extension. Shouldn't cause any issues, but keeping it here until future decisions have been made.
+				"sqltools.useNodeRuntime": true,
+				"sqltools.connections": [
+					{
+						"previewLimit": 50,
+						"driver": "SQLite",
+						"name": "wdfp_data",
+						"group": "wdfp",
+						"database": "${workspaceFolder:starpoint}/.database/wdfp_data.db"
+					}
+				]
+			},
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.debugpy",
+				"yzhang.markdown-all-in-one",
+				"DavidAnson.vscode-markdownlint",
+				"bradlc.vscode-tailwindcss",
+				"mikestead.dotenv",
+				"eamodio.gitlens",
+				"christian-kohler.npm-intellisense",
+				"coolbear.systemd-unit-file",
+				"dbaeumer.vscode-eslint",
+				"william-voyek.vscode-nginx",
+				"geeksharp.openssl-configuration-file",
+				"qwtel.sqlite-viewer",
+				"mtxr.sqltools-driver-sqlite"
+			]
+	  	}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,22 +9,27 @@
             "request": "launch",
             "runtimeArgs": [
                 "run",
-                "debug"
+                "debug:ts-only"
             ],
             "runtimeExecutable": "npm",
             "skipFiles": [
                 "<node_internals>/**"
             ],
             "type": "node",
-            "autoAttachChildProcesses": true,
+            "autoAttachChildProcesses": true
         }
     ],
 
     "compounds": [
         {
-            "name": "Starpoint with mitmweb",
+            "name": "Debug All w/ Wireguard",
             "configurations": ["Launch via NPM"],
-            "preLaunchTask": "mitmweb with wireguard"
+            "preLaunchTask": "Debug Wireguard background tasks",
+        },
+        {
+            "name": "Debug All",
+            "configurations": ["Launch via NPM"],
+            "preLaunchTask": "Debug background tasks",
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,45 +3,185 @@
     // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
-        {
-            "label": "mitmweb with wireguard",
-            "type": "shell",
-            //TODO: Replace this with platform-specific commands (eventually) to remove repetition
-            //TODO: Maybe a mitmproxy option would be better, to keep it in the terminal just in case? This would not allow QR code generation, though. Consider things.
-            "command": "mitmweb --mode wireguard --set connection_strategy=lazy --allow-hosts gc-openapi-zinny3.kakaogames.com --allow-hosts gc-infodesk-zinny3.kakaogames.com --allow-hosts na.wdfp.kakaogames.com --allow-hosts patch.wdfp.kakaogames.com -s scripts/mitm-redirect-traffic.py",
-            "promptOnClose": true,
-            "isBackground": true,
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": false
+      {
+        "label": "mitmweb with wireguard",
+        "type": "shell",
+        "command": "mitmweb --mode wireguard --set connection_strategy=lazy --allow-hosts gc-openapi-zinny3.kakaogames.com --allow-hosts gc-infodesk-zinny3.kakaogames.com --allow-hosts na.wdfp.kakaogames.com --allow-hosts patch.wdfp.kakaogames.com -s scripts/mitm-redirect-traffic.py",
+        "promptOnClose": true,
+        "isBackground": true,
+        "presentation": {
+          "echo": true,
+          "reveal": "always",
+          "focus": false,
+          "panel": "shared",
+          "showReuseMessage": true,
+          "clear": false
+        },
+        "runOptions": {
+          "instanceLimit": 1
+        },
+        "problemMatcher": {
+          "owner": "mitmweb",
+          "fileLocation": [
+            "relative",
+            "${workspaceFolder}"
+          ],
+          "source": "script",
+          //TODO: This pattern works on the actual message text copied over. Determine why it does not work here.
+          "pattern": [
+            {
+              "regexp": ".*(error) in script (.+)",
+              "file": 2,
+              "severity": 1,
+              "kind": "file"
             },
-            "problemMatcher": {
-                "owner": "mitmweb",
-                "fileLocation": ["relative", "${workspaceFolder}"],
-                "source": "script",
-                "pattern": [
-                  {
-                    //TODO: This isn't really working yet, even though the pattern works in Javascript testing sites. Investigate/fix that later.
-                    //For now, this at least prevents warnings getting thrown up
-                    "regexp": ".*(error) in script (.+)",
-                    // "line": 1,
-                    // "column": 2,
-                    "file": 2,
-                    "severity": 1,
-                    "kind": "file"
-                    // "code": 5
-                  },
-                  {
-                    "regexp": "^(.+)$",
-                    "message": 1,
-                    "loop": true
-                  }
-                ]
-              }
+            {
+              "regexp": "^(.+)$",
+              "message": 1,
+              "loop": true
+            }
+          ],
+          "background": {
+            "activeOnStart": false,
+            "beginsPattern": "------------------------------------------------------------",
+            "endsPattern": ".*listening at.*"
+          }
         }
+      },
+      {
+        "label": "mitmweb",
+        "type": "shell",
+        "command": "mitmweb --set connection_strategy=lazy --allow-hosts gc-openapi-zinny3.kakaogames.com --allow-hosts gc-infodesk-zinny3.kakaogames.com --allow-hosts na.wdfp.kakaogames.com --allow-hosts patch.wdfp.kakaogames.com -s scripts/mitm-redirect-traffic.py",
+        "promptOnClose": true,
+        "isBackground": true,
+        "presentation": {
+          "echo": true,
+          "reveal": "always",
+          "focus": false,
+          "panel": "shared",
+          "showReuseMessage": true,
+          "clear": false
+        },
+        "runOptions": {
+          "instanceLimit": 1
+        },
+        "problemMatcher": {
+          "owner": "mitmweb",
+          "fileLocation": [
+            "relative",
+            "${workspaceFolder}"
+          ],
+          "source": "script",
+          //TODO: This pattern works on the actual message text copied over. Determine why it does not work here.
+          "pattern": [
+            {
+              "regexp": ".*(error) in script (.+)",
+              "file": 2,
+              "severity": 1,
+              "kind": "file"
+            },
+            {
+              "regexp": "^(.+)$",
+              "message": 1,
+              "loop": true
+            }
+          ],
+          "background": {
+            "activeOnStart": false,
+            "beginsPattern": ".*HTTP\\(S\\) proxy listening.*",
+            "endsPattern": ".*listening at.*"
+          }
+        }
+      },
+      {
+        "label": "Build CSS",
+        "type": "shell",
+        "command": "npm run css",
+        "promptOnClose": true,
+        "runOptions": {
+          "instanceLimit": 1
+        },
+        "problemMatcher": {
+          "source": "Tailwind CSS",
+          "applyTo": "allDocuments",
+          "owner": "tailwindcss",
+          "pattern": [
+            {
+              "regexp": "^([^\\\\s].*)\\\\((\\\\d+,\\\\d+)\\\\):\\\\s*(.*)$",
+              "file": 1,
+              "location": 2,
+              "message": 3
+            }
+          ]
+        }
+      },
+
+      {
+        //Note: This one stops running at the first sign of trouble and needs to be manually restarted when it fails to run right
+        "label": "CSS watch",
+        "type": "shell",
+        "command": "npm run css:watch",
+        "promptOnClose": true,
+        "isBackground": true,
+        "runOptions": {
+          "instanceLimit": 1
+        },
+        "problemMatcher": {
+          "source": "Tailwind CSS watch",
+          "applyTo": "allDocuments",
+          "owner": "tailwindcss",
+          "pattern": [
+            {
+              "regexp": "^([^\\\\s].*)\\\\((\\\\d+,\\\\d+)\\\\):\\\\s*(.*)$",
+              "file": 1,
+              "location": 2,
+              "message": 3
+            }
+          ],
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": {
+              "regexp": "Rebuilding.*"
+            },
+            "endsPattern": {
+              "regexp": "Done.*"
+            }
+          }
+        }
+      },
+      {
+        "label": "Build starpoint",
+        "type": "shell",
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        },
+        "command": "npm run build",
+        "problemMatcher": "$tsc"
+      },
+      {
+        "label": "Debug Wireguard background tasks",
+        "type": "shell",
+        "isBackground": false,
+        "dependsOn": [
+          "CSS watch",
+          "mitmweb with wireguard"
+        ],
+        "group": "none",
+        "dependsOrder": "parallel",
+        "problemMatcher": []
+      },
+      {
+        "label": "Debug background tasks",
+        "type": "shell",
+        "isBackground": false,
+        "dependsOn": [
+          "CSS watch",
+          "mitmweb"
+        ],
+        "group": "none",
+        "dependsOrder": "parallel",
+        "problemMatcher": []
+      }
     ]
 }

--- a/deployment/devenv/starpoint-devcontainer-setup.sh
+++ b/deployment/devenv/starpoint-devcontainer-setup.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env dash
+#TODO: The above may need to change if attempting to reuse in Alpine Linux, due to that terminal being ash, not dash.
+#Currently dash to enable use of 'local', but if not needed just make it /bin/sh probably
+#Commands to run after build to create a dev environment
+
+#Fix issue where sometimes pulling from Git gives the wrong line endings to this file. This should usually not be CLRF....
+#Running this each time we start the thing up, but during construction we want this sooner
+tempHoldEdit="$(tr -d '\r' < .shellcheckrc)"
+printf "%s" "$tempHoldEdit" > .shellcheckrc
+
+#Support fixing only the files that need fixing in script form, so we don't need to repeat that everywhere, then exit.
+#TODO: Have it do this for all of the startup scripts as well?
+if [ "$1" = "--fix-file-escapes-only" ]; then
+    exit 0
+fi
+
+#We DO trust this git repo, but it's not owned by the "node" user, so mark it safe for us.
+git config --global --add safe.directory "$(pwd)"
+
+#Because the feature version of this has had access problems (404 error for download at last attempt), install with pipx instead
+pipx install mitmproxy
+
+python3 -m venv ~/starpoint-venv
+# shellcheck disable=SC1091
+. "$HOME/starpoint-venv/bin/activate"
+pip install -r scripts/requirements.txt
+#This way we get the source code for the mitmproxy API as well
+pip install mitmproxy
+deactivate
+tput sgr0
+
+starpy_greeting_part="To activate python venv in the terminal, you can use the 'starpy' alias. VENV is located in $HOME/starpoint-venv. It is the default env used by VSCode."
+
+cat <<EOF | tee -a ~/.bashrc >> ~/.zshrc
+
+alias starpy=". $HOME/starpoint-venv/bin/activate"
+echo "$starpy_greeting_part"
+EOF
+
+npm ci || npm install

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "scripts": {
     "build": "npx tsc & npm run css",
     "css": "npx tailwindcss -i ./src/input.css -o ./web/public/tailwind.css",
+    "css:watch": "npx tailwindcss -i ./src/input.css -o ./web/public/tailwind.css --watch --poll",
     "dev": "npm run build && node --env-file=.env out/server.js",
     "cdn": "npx tsc & node --env-file=.env out/validate_cdn.js",
     "unzip": "npx tsc & node --env-file=.env out/unzip_cdn.js",
-    "debug": "npm run css && tsnd --inspect -- src/server.ts"
+    "debug": "npm run css && npm run css:watch & npm run debug:ts-only",
+    "debug:ts-only": "tsnd --inspect -- src/server.ts"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
# Update launch & tasks for vscode & npm:
- Add CSS watch tasks for tailwindcss for continuous debugging & building
    - Currently exits on the first bad compile attempt. Can't find a way to get it to not do that. Will need to experiment with auto-restarting scripts later.
- Now allows starting mitmproxy in standard or Wireguard mode via tasks. Debug options with either method exist
- Add npm tasks for all of the above

# DevContainer support
- Add initial devcontainer support. Builds full env including supporting mitmproxy using a debian bookworm installation and minimal "extras"
- Includes VSCode extensions to support all the file types currently contained within the repo at time of commit
- Preconfigure some extensions to enable support within the project
- Add setup script to prepare the environment when building the container and ensure certain files have their line endings in LF format

Willing to tweak or separate this into 2 PRs as needed