### PR TITLE
Refactor .local domains to .internal

### DIFF
--- a/deployment/linux/dns/starpoint_proxy_dnsmasq.conf
+++ b/deployment/linux/dns/starpoint_proxy_dnsmasq.conf
@@ -1,6 +1,6 @@
 #Server endpoints for use with proxy to locally-running starpoint
 #Replace with static IP for your proxy
-address=/starpoint.local/PUT PROXY IP HERE
+address=/starpoint.internal/PUT PROXY IP HERE
 address=/na.wdfp.kakaogames.com/PUT PROXY IP HERE
 address=/patch.wdfp.kakaogames.com/PUT PROXY IP HERE
 address=/openapi-zinny3.game.kakao.com/PUT PROXY IP HERE

--- a/deployment/nginx/starpoint_proxy.nginx
+++ b/deployment/nginx/starpoint_proxy.nginx
@@ -20,7 +20,7 @@ server {
         listen 80;
         listen [::]:80;
 
-        server_name starpoint.local;
+        server_name starpoint.internal;
 
         location / {
                 proxy_set_header Host $host;

--- a/deployment/ssl/ssl_gen_self_sign_certs.sh
+++ b/deployment/ssl/ssl_gen_self_sign_certs.sh
@@ -20,8 +20,10 @@ delete_generated () {
 copy_certs () {
     ensure_root "Please run as root to allow automatically copying certificates"
 
-    cp -fv `find $ssl_tempdir -name *.crt` /etc/ssl/certs/
-    cp -fv `find $ssl_tempdir -name *.key` /etc/ssl/private/
+    # shellcheck disable=SC2046
+    cp -fv $(find "$ssl_tempdir" -name "*.crt") /etc/ssl/certs/
+    # shellcheck disable=SC2046
+    cp -fv $(find "$ssl_tempdir" -name "*.key") /etc/ssl/private/
 }
 
 print_syntax () {
@@ -78,7 +80,7 @@ openssl req -x509 -new -subj "/CN=gc-infodesk-zinny3.kakaogames.com" -config $SC
 set +e
 
 #This should not normally be necessary, but included in case it is for your environment
-#openssl req -x509 -new -subj "/CN=starpoint.local" -config $SCRIPT_DIR/starpoint.cnf -key generated/starpoint_multiversal.key -out generated/starpoint_local.crt
+#openssl req -x509 -new -subj "/CN=starpoint.internal" -config $SCRIPT_DIR/starpoint.cnf -key generated/starpoint_multiversal.key -out generated/starpoint_local.crt
 if [ "$do_copy" = true ]; then
     copy_certs
     default_delete_tempdir=true


### PR DESCRIPTION
Turns out that .local is actually a reserved TLD for multicast DNS, and I only realized this after having issues configuring something on my network for days.

As a result, I've instead subbed it for .internal, which was formally reserved on 07/29/2024 for the purpose of internal applications. This should prevent a few potential headaches from happening.